### PR TITLE
refactor: Update nginx configuration to proxy API requests

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -9,21 +9,20 @@ http {
   sendfile        on;
   keepalive_timeout  65;
 
-    server {
-      listen       80;
-      server_name  localhost;
+  server {
+    listen       80;
+    server_name  localhost;
 
-      root   /usr/share/nginx/html;
-      index  index.html index.htm;
-      try_files $uri $uri/ /index.html;
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
 
-      localhost /api {
-        proxy_pass http://api-metas:4020/api/v1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-      }
-
+    location /api {
+      proxy_pass http://api-metas:4020/api/v1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
     }
+  }
 }


### PR DESCRIPTION
This commit updates the nginx configuration file to include a new location block for proxying API requests to the backend server. The previous configuration only had a server block for serving static files. With this change, any requests to the /api path will be proxied to the backend server running at http://api-metas:4020/api/v1. This will enable the frontend to communicate with the backend API.